### PR TITLE
EPA-100: fix l'erreur liée aux cannot-read-properties aux dev et prod

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=https://postnova-ai-server.onrender.com/api

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_BASE_URL=http://localhost:8000/api

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,10 +1,8 @@
 # 📝 Backlog Jira Sync
 
-## À faire
-
-
-
-## En cours
+[EPA-100] Fix cannot read-properties aux prod et dev. (Assigné à: Mialisoa Lisa Rasoanirina)
+ Branche: `fix/EPA-100-cannot-read-properties`
+ Commit: `EPA-100: fix l'erreur liée aux cannot-read-properties aux dev et prod`
 
 -[EPA-95] Configuration de la redirection, page netlify (Assigné à: Mialisoa Lisa Rasoanirina)
  Branche: `chore/EPA-95-netlify-toml`

--- a/src/app/components/Home/PopularContent.jsx
+++ b/src/app/components/Home/PopularContent.jsx
@@ -17,14 +17,14 @@ const PopularContent = () => {
 	}, []);
 
 	useEffect(() => {
-		if (campaigns.length === 0) return;
+		if (!campaigns || campaigns.length === 0) return;
 		const interval = setInterval(() => {
 			setCurrentIndex((prevIndex) => (prevIndex + 1) % campaigns.length);
 		}, 2000);
 		return () => clearInterval(interval);
 	}, [campaigns]);
 
-	if (campaigns.length === 0) {
+	if (!campaigns || campaigns.length === 0) {
 		return (
 			<p className="text-center py-20 text-lg">
 				Chargement des contenus populaires...

--- a/src/configs/api.js
+++ b/src/configs/api.js
@@ -1,7 +1,6 @@
 import axios from "axios";
 
-//const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}`;
-const API_BASE_URL = `/api`;
+const API_BASE_URL = `${import.meta.env.VITE_API_BASE_URL}`;
 
 const api = axios.create({
 	baseURL: API_BASE_URL,

--- a/src/services/campaignService.js
+++ b/src/services/campaignService.js
@@ -62,14 +62,23 @@ export const campaignService = {
 			const response = await api.get("/campaigns/popular/content");
 			return {
 				success: true,
-				data: response.data.data,
-				totals: response.data.totals,
+				data: response.data?.data || [],
+				totals: response.data?.totals || {},
 			};
 		} catch (error) {
-			return handleError(
-				error,
-				"Impossible de récupérer les campagnes populaires"
-			);
+			if (process.env.NODE_ENV === "development") {
+				console.warn(
+					"Erreur campagnes populaires (visible seulement en dev):",
+					error
+				);
+			}
+
+			return {
+				success: false,
+				data: [],
+				totals: {},
+				error: "Service temporairement indisponible",
+			};
 		}
 	},
 


### PR DESCRIPTION
Cette PR corrige les erreurs "Cannot read properties of undefined" en développement et production. Elle sécurise l'accès aux propriétés des campagnes en ajoutant des vérifications de nullité et des valeurs par défaut. L'UI reste stable, sans crash même en l'absence de données ou lors d'indisponibilité du server.